### PR TITLE
Persist API token in localStorage with expiry

### DIFF
--- a/src/client/lib/apis.ts
+++ b/src/client/lib/apis.ts
@@ -1,3 +1,4 @@
+import { API_TOKEN_INVALID_HTTP_STATUS } from './constants';
 import { APIResponse, ConflictResponse } from './types';
 
 const baseURL = 'https://api.andycodes.ru';
@@ -18,7 +19,7 @@ export async function getAllCollisions(spreadsheetID: string, token: string): Pr
       });
 
       if (!response.ok) {
-        if (response.status === 401) {
+        if (response.status === API_TOKEN_INVALID_HTTP_STATUS) {
           return { success: false, error: "The API token you provided is wrong" };
         }
 

--- a/src/client/lib/constants.ts
+++ b/src/client/lib/constants.ts
@@ -1,0 +1,2 @@
+export const TOKEN_EXPIRY_DAYS = 0.95
+export const API_TOKEN_INVALID_HTTP_STATUS = 401

--- a/src/client/lib/utils.ts
+++ b/src/client/lib/utils.ts
@@ -46,12 +46,14 @@ export function groupNameToDisplayText(name: string | string[]): string {
   return name;
 }
 
-
-
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function getLengthOf2DArray(array: any[][]): number {
   return array.reduce((total, row) => total + row.length, 0)
+}
+
+export function millisecondsToDays(milliseconds: number): number {
+  return milliseconds / 1000 / 60 / 60 / 24
 }

--- a/src/client/plugin/components/Main.tsx
+++ b/src/client/plugin/components/Main.tsx
@@ -70,7 +70,6 @@ export default function Main() {
   const currentYear = new Date().getFullYear();
 
   async function getConflicts() {
-    console.log(token);
     if (token === undefined || token === '') {
       dispatch({
         type: ActionType.REQUEST_FAILED,
@@ -98,7 +97,7 @@ export default function Main() {
       <h1>
         InNo<span className="text-innohassle">Hassle</span> SCR
       </h1>
-      <p>
+      <div>
         To test the compatibility of the schedule:
         <ol className="list-decimal text-start">
           <li>
@@ -115,7 +114,7 @@ export default function Main() {
           <li>Paste the token in the field below</li>
           <li>Press the button "Check the schedule"</li>
         </ol>
-      </p>
+      </div>
       <APIForm />
       <button
         className="bg-innohassle disabled:bg-innohassle/50 text-base py-1 px-6 text-center rounded-full hover:brightness-75 disabled:hover:brightness-100 flex items-center justify-center gap-2"
@@ -204,7 +203,7 @@ export default function Main() {
 
       <div className="flex flex-col gap-3">
         {filteredConflicts.map((data, index) => (
-          <div className="flex flex-col gap-10">
+          <div key={index} className="flex flex-col gap-10">
             {data.map((data2, index2) => (
               <Card key={index * data.length + index2} lesson={data2} />
             ))}

--- a/src/client/plugin/components/apiToken/provider.tsx
+++ b/src/client/plugin/components/apiToken/provider.tsx
@@ -3,14 +3,40 @@ import { useState } from 'react';
 import { type ApiContextI } from '../../contexts/apiTokenContext';
 import apiContext from '../../contexts/apiTokenContext';
 
+type tokenStorageType = {
+  token: string
+  savedAt: string
+}
+
+
 export default function ApiTokenProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const [token, setToken] = useState<ApiContextI['token']>(undefined);
+  const [token, setToken] = useState<ApiContextI['token']>(() => {
+    const storage = localStorage.getItem("saved-api-token")
+    if (storage == null) { return undefined }
+
+    const received: tokenStorageType = JSON.parse(storage)
+    const currentDate = new Date()
+    const savedDate = new Date(received.savedAt)
+    const timeDiffInMilliseconds = currentDate.getTime() - savedDate.getTime()
+    const daysBetween = timeDiffInMilliseconds / 1000 / 60 / 60 / 24
+
+    if (daysBetween >= 0.95) {
+      localStorage.removeItem("saved-api-token")
+      return undefined
+    }
+
+    return received.token
+  });
 
   function updateToken(newToken: string) {
+    localStorage.setItem("saved-api-token", JSON.stringify({
+      token: newToken,
+      savedAt: new Date()
+    }))
     setToken(newToken);
   }
 

--- a/src/client/plugin/components/apiToken/provider.tsx
+++ b/src/client/plugin/components/apiToken/provider.tsx
@@ -32,7 +32,7 @@ export default function ApiTokenProvider({
     const timeDiffInMilliseconds = currentDate.getTime() - savedDate.getTime();
     const daysBetween = millisecondsToDays(timeDiffInMilliseconds);
 
-    if (daysBetween >= 0.95) {
+    if (daysBetween >= TOKEN_EXPIRY_DAYS) {
       localStorage.removeItem("saved-api-token");
       return undefined;
     }

--- a/src/client/plugin/components/apiToken/provider.tsx
+++ b/src/client/plugin/components/apiToken/provider.tsx
@@ -18,18 +18,24 @@ export default function ApiTokenProvider({
     const storage = localStorage.getItem("saved-api-token")
     if (storage == null) { return undefined }
 
-    const received: tokenStorageType = JSON.parse(storage)
-    const currentDate = new Date()
-    const savedDate = new Date(received.savedAt)
-    const timeDiffInMilliseconds = currentDate.getTime() - savedDate.getTime()
-    const daysBetween = timeDiffInMilliseconds / 1000 / 60 / 60 / 24
+    let received: tokenStorageType;
+    try {
+      received = JSON.parse(storage);
+    } catch (error) {
+      console.error("Failed to parse saved API token:", error);
+      return undefined;
+    }
+    const currentDate = new Date();
+    const savedDate = new Date(received.savedAt);
+    const timeDiffInMilliseconds = currentDate.getTime() - savedDate.getTime();
+    const daysBetween = timeDiffInMilliseconds / 1000 / 60 / 60 / 24;
 
     if (daysBetween >= 0.95) {
-      localStorage.removeItem("saved-api-token")
-      return undefined
+      localStorage.removeItem("saved-api-token");
+      return undefined;
     }
 
-    return received.token
+    return received.token;
   });
 
   function updateToken(newToken: string) {

--- a/src/client/plugin/components/apiToken/provider.tsx
+++ b/src/client/plugin/components/apiToken/provider.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 
 import { type ApiContextI } from '../../contexts/apiTokenContext';
 import apiContext from '../../contexts/apiTokenContext';
+import { TOKEN_EXPIRY_DAYS } from '../../../lib/constants';
+import { millisecondsToDays } from '../../../lib/utils';
 
 type tokenStorageType = {
   token: string
@@ -28,7 +30,7 @@ export default function ApiTokenProvider({
     const currentDate = new Date();
     const savedDate = new Date(received.savedAt);
     const timeDiffInMilliseconds = currentDate.getTime() - savedDate.getTime();
-    const daysBetween = timeDiffInMilliseconds / 1000 / 60 / 60 / 24;
+    const daysBetween = millisecondsToDays(timeDiffInMilliseconds);
 
     if (daysBetween >= 0.95) {
       localStorage.removeItem("saved-api-token");
@@ -41,7 +43,7 @@ export default function ApiTokenProvider({
   function updateToken(newToken: string) {
     localStorage.setItem("saved-api-token", JSON.stringify({
       token: newToken,
-      savedAt: new Date()
+      savedAt: new Date().toISOString(),
     }))
     setToken(newToken);
   }


### PR DESCRIPTION
This pull request updates the `ApiTokenProvider` component in `src/client/plugin/components/apiToken/provider.tsx` to enhance token management by introducing local storage functionality with expiration logic. The most important change is the addition of logic to persist the API token in local storage and automatically remove it if it has expired.

Enhancements to token management:

* Added a new `tokenStorageType` type to define the structure of the token object stored in local storage, including the token and its save date.
* Modified the `useState` initialization for `token` to check local storage for a saved token, validate its expiration based on the save date, and remove it if it has expired (expiration set to approximately 0.95 days).
* Updated the `updateToken` function to store the new token and its save date in local storage whenever the token is updated.